### PR TITLE
Update to 1.19.3 and 1.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.+'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.5
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.1
 	loader_version=0.14.17
 
 # Mod Properties
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = aquatictorches
 
 # Dependencies
-	fabric_version=0.76.0+1.19.3
+	fabric_version=0.76.0+1.19.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19
-	yarn_mappings=1.19+build.4
-	loader_version=0.14.8
+	minecraft_version=1.19.3
+	yarn_mappings=1.19.3+build.5
+	loader_version=0.14.17
 
 # Mod Properties
 	mod_version = 1.0.0
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = aquatictorches
 
 # Dependencies
-	fabric_version=0.56.1+1.19
+	fabric_version=0.76.0+1.19.3

--- a/src/main/java/realmayus/aquatictorches/AquaticTorches.java
+++ b/src/main/java/realmayus/aquatictorches/AquaticTorches.java
@@ -1,29 +1,35 @@
 package realmayus.aquatictorches;
 
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.Material;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroup;
-import net.minecraft.item.WallStandingBlockItem;
-import net.minecraft.particle.ParticleTypes;
-import net.minecraft.sound.BlockSoundGroup;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.block.Material;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroups;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.VerticallyAttachableBlockItem;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.sound.BlockSoundGroup;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Direction;
 
 public class AquaticTorches implements ModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("aquatictorches");
 	public static final AquaticTorchBlock AQUATIC_TORCH = new AquaticTorchBlock(FabricBlockSettings.of(Material.DECORATION).noCollision().breakInstantly().luminance(15).sounds(BlockSoundGroup.WOOD), ParticleTypes.FLAME);
 	public static final AquaticWallTorchBlock AQUATIC_WALL_TORCH = new AquaticWallTorchBlock(FabricBlockSettings.of(Material.DECORATION).noCollision().breakInstantly().luminance(15).sounds(BlockSoundGroup.WOOD), ParticleTypes.FLAME);
+
 	@Override
 	public void onInitialize() {
-		Registry.register(Registry.BLOCK, new Identifier("aquatictorches", "aquatic_torch"), AQUATIC_TORCH);
-		Registry.register(Registry.BLOCK, new Identifier("aquatictorches", "aquatic_wall_torch"), AQUATIC_WALL_TORCH);
+		Registry.register(Registries.BLOCK, new Identifier("aquatictorches", "aquatic_torch"), AQUATIC_TORCH);
+		Registry.register(Registries.BLOCK, new Identifier("aquatictorches", "aquatic_wall_torch"), AQUATIC_WALL_TORCH);
+		Registry.register(Registries.ITEM, new Identifier("aquatictorches", "aquatic_torch"), new VerticallyAttachableBlockItem(AQUATIC_TORCH, AQUATIC_WALL_TORCH, new Item.Settings(), Direction.DOWN));
 
-		Registry.register(Registry.ITEM, new Identifier("aquatictorches", "aquatic_torch"), new WallStandingBlockItem(AQUATIC_TORCH, AQUATIC_WALL_TORCH, new Item.Settings().group(ItemGroup.DECORATIONS)));
-
+		ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(entries -> entries.addAfter(Items.REDSTONE_TORCH, new ItemStack(AQUATIC_WALL_TORCH)));
 	}
 }

--- a/src/main/java/realmayus/aquatictorches/AquaticWallTorchBlock.java
+++ b/src/main/java/realmayus/aquatictorches/AquaticWallTorchBlock.java
@@ -102,7 +102,7 @@ public class AquaticWallTorchBlock extends WallTorchBlock implements Waterloggab
     @Override
     public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
         if (state.get(WATERLOGGED)) {
-            world.createAndScheduleFluidTick(pos, Fluids.WATER, Fluids.WATER.getTickRate(world));
+            world.scheduleFluidTick(pos, Fluids.WATER, Fluids.WATER.getTickRate(world));
         }
         if (direction.getOpposite() == state.get(FACING) && !state.isFullCube(world, pos)) {
             return Blocks.AIR.getDefaultState();


### PR DESCRIPTION
The aquatic torch item is now found in the functional block tags right after the redstone torch. This version works for both Minecraft 1.19.3 and Minecraft 1.19.4.